### PR TITLE
New feature: checkpoint training resume

### DIFF
--- a/examples/micro_geolifeclef/cnn_on_rgb_nir_patches.py
+++ b/examples/micro_geolifeclef/cnn_on_rgb_nir_patches.py
@@ -212,8 +212,8 @@ def main(cfg: DictConfig) -> None:
     ]
     trainer = pl.Trainer(logger=logger, callbacks=callbacks, **cfg.trainer)
 
-    if cfg.inference.predict:
-        model_loaded = ClassificationSystem.load_from_checkpoint(cfg.inference.checkpoint_path,
+    if cfg.run.predict:
+        model_loaded = ClassificationSystem.load_from_checkpoint(cfg.run.checkpoint_path,
                                                                  model=model.model,
                                                                  hparams_preprocess=False)
 
@@ -225,12 +225,12 @@ def main(cfg: DictConfig) -> None:
         test_data = datamodule.get_test_dataset()
         test_data_point = test_data[0][0]
         test_data_point = test_data_point.resize_(1, *test_data_point.shape)
-        prediction = model_loaded.predict_point(cfg.inference.checkpoint_path,
+        prediction = model_loaded.predict_point(cfg.run.checkpoint_path,
                                                 test_data_point,
                                                 ['model.', ''])
         print('Point prediction : ', prediction)
     else:
-        trainer.fit(model, datamodule=datamodule)
+        trainer.fit(model, datamodule=datamodule, ckpt_path=cfg.run.checkpoint_path)
         trainer.validate(model, datamodule=datamodule)
 
 

--- a/examples/micro_geolifeclef/cnn_on_rgb_patches.py
+++ b/examples/micro_geolifeclef/cnn_on_rgb_patches.py
@@ -178,8 +178,8 @@ def main(cfg: DictConfig) -> None:
     ]
     trainer = pl.Trainer(logger=logger, callbacks=callbacks, **cfg.trainer)
 
-    if cfg.inference.predict:
-        model_loaded = ClassificationSystem.load_from_checkpoint(cfg.inference.checkpoint_path,
+    if cfg.run.predict:
+        model_loaded = ClassificationSystem.load_from_checkpoint(cfg.run.checkpoint_path,
                                                                  model=model.model,
                                                                  hparams_preprocess=False)
 
@@ -191,12 +191,12 @@ def main(cfg: DictConfig) -> None:
         test_data = datamodule.get_test_dataset()
         test_data_point = test_data[0][0]
         test_data_point = test_data_point.resize_(1, *test_data_point.shape)
-        prediction = model_loaded.predict_point(cfg.inference.checkpoint_path,
+        prediction = model_loaded.predict_point(cfg.run.checkpoint_path,
                                                 test_data_point,
                                                 ['model.', ''])
         print('Point prediction : ', prediction)
     else:
-        trainer.fit(model, datamodule=datamodule)
+        trainer.fit(model, datamodule=datamodule, ckpt_path=cfg.run.checkpoint_path)
         trainer.validate(model, datamodule=datamodule)
 
 

--- a/examples/micro_geolifeclef/config/cnn_on_rgb_nir_patches_config.yaml
+++ b/examples/micro_geolifeclef/config/cnn_on_rgb_nir_patches_config.yaml
@@ -3,7 +3,7 @@ defaults:
 
 run:
   predict: false
-  checkpoint_path: "../2023-08-03_18-52-45/checkpoint-epoch=00-step=244-val_multiclass_accuracy=0.0771.ckpt"
+  checkpoint_path: "../2023-08-03_18-52-45/checkpoint-epoch=00-step=244-val_multiclass_accuracy=0.0771.ckpt"  # Relative to hydra.run.dir
 
 model:
   modifiers:

--- a/examples/micro_geolifeclef/config/cnn_on_rgb_nir_patches_config.yaml
+++ b/examples/micro_geolifeclef/config/cnn_on_rgb_nir_patches_config.yaml
@@ -1,8 +1,8 @@
 defaults:
   - cnn_on_rgb_patches_config
 
-inference:
-  predict: true
+run:
+  predict: false
   checkpoint_path: "../2023-08-03_18-52-45/checkpoint-epoch=00-step=244-val_multiclass_accuracy=0.0771.ckpt"
 
 model:

--- a/examples/micro_geolifeclef/config/cnn_on_rgb_patches_config.yaml
+++ b/examples/micro_geolifeclef/config/cnn_on_rgb_patches_config.yaml
@@ -10,15 +10,15 @@ trainer:
   #val_check_interval: 10
   check_val_every_n_epoch: 1
 
-inference:
-  predict: true
+run:
+  predict: false
   checkpoint_path: "../2023-08-03_18-44-35/checkpoint-epoch=00-step=244-val_multiclass_accuracy=0.0570.ckpt"
 
 model:
   provider_name: "timm"  # choose from ["timm", "torchvision"]
   model_name: "resnet18"
   model_kwargs:
-    pretrained: false  # Deprecated in torchvision since 0.13 (replaced by "weights") but used by timm
+    pretrained: true  # Deprecated in torchvision since 0.13 (replaced by "weights") but used by timm
     num_classes:
     in_chans:
     output_stride:

--- a/examples/micro_geolifeclef/config/cnn_on_rgb_patches_config.yaml
+++ b/examples/micro_geolifeclef/config/cnn_on_rgb_patches_config.yaml
@@ -12,7 +12,7 @@ trainer:
 
 run:
   predict: false
-  checkpoint_path: "../2023-08-03_18-44-35/checkpoint-epoch=00-step=244-val_multiclass_accuracy=0.0570.ckpt"
+  checkpoint_path: "../2023-08-03_18-44-35/checkpoint-epoch=00-step=244-val_multiclass_accuracy=0.0570.ckpt"  # Relative to hydra.run.dir
 
 model:
   provider_name: "timm"  # choose from ["timm", "torchvision"]

--- a/examples/sentinel2_raster_torchgeo/cnn_on_rgbnir_torchgeo.py
+++ b/examples/sentinel2_raster_torchgeo/cnn_on_rgbnir_torchgeo.py
@@ -284,8 +284,8 @@ def main(cfg: DictConfig) -> None:
     ]
     trainer = pl.Trainer(logger=logger, callbacks=callbacks, **cfg.trainer)
 
-    if cfg.inference.predict:
-        model_loaded = ClassificationSystem.load_from_checkpoint(cfg.inference.checkpoint_path,
+    if cfg.run.predict:
+        model_loaded = ClassificationSystem.load_from_checkpoint(cfg.run.checkpoint_path,
                                                                  model=model.model,
                                                                  hparams_preprocess=False)
 
@@ -301,12 +301,12 @@ def main(cfg: DictConfig) -> None:
                        'units': datamodule.units}
         test_data_point = test_data[query_point][0]
         test_data_point = test_data_point.resize_(1, *test_data_point.shape)
-        prediction = model_loaded.predict_point(cfg.inference.checkpoint_path,
+        prediction = model_loaded.predict_point(cfg.run.checkpoint_path,
                                                 test_data_point,
                                                 ['model.', ''])
         print('Point prediction : ', prediction)
     else:
-        trainer.fit(model, datamodule=datamodule)
+        trainer.fit(model, datamodule=datamodule, ckpt_path=cfg.run.checkpoint_path)
         trainer.validate(model, datamodule=datamodule)
 
 

--- a/examples/sentinel2_raster_torchgeo/config/cnn_on_rgbnir_torchgeo_config.yaml
+++ b/examples/sentinel2_raster_torchgeo/config/cnn_on_rgbnir_torchgeo_config.yaml
@@ -12,7 +12,7 @@ trainer:
 
 run:
   predict: false
-  checkpoint_path: "../2023-08-02_18-24-15/checkpoint-epoch=00-step=3-val_multiclass_accuracy=0.0000.ckpt"
+  checkpoint_path: "../2023-08-02_18-24-15/checkpoint-epoch=00-step=3-val_multiclass_accuracy=0.0000.ckpt"  # Relative to hydra.run.dir
                                                                                                                                        
 model:
   provider_name: "timm"  # choose from ["timm", "torchvision"]

--- a/examples/sentinel2_raster_torchgeo/config/cnn_on_rgbnir_torchgeo_config.yaml
+++ b/examples/sentinel2_raster_torchgeo/config/cnn_on_rgbnir_torchgeo_config.yaml
@@ -10,15 +10,15 @@ trainer:
   # val_check_interval: 10
   check_val_every_n_epoch: 1
 
-inference:
+run:
   predict: false
   checkpoint_path: "../2023-08-02_18-24-15/checkpoint-epoch=00-step=3-val_multiclass_accuracy=0.0000.ckpt"
-
+                                                                                                                                       
 model:
   provider_name: "timm"  # choose from ["timm", "torchvision"]
   model_name: "resnet18"
   model_kwargs:
-    pretrained: false  # Deprecated in torchvision since 0.13 (replaced by "weights") but used by timm
+    pretrained: true  # Deprecated in torchvision since 0.13 (replaced by "weights") but used by timm
     num_classes:
     in_chans:
     output_stride:


### PR DESCRIPTION
# Resuming trainings with checkpoint weights

This PR addresses issue #14 and adds the possibility of loading weights through PyTorch checkpoints to resume interrupted or completed runs, simply by indicating a value in the experiment config file at the following key : `run.checkpoint_path`. The value can either be `None` (no value), or a string of the path to the desired checkpoint file. However, the key must exists for the well being of example scripts.

The implementation simply passes the `checkpoint_path` value to the PyTorch Lightning `trainer` when fitting the model, as a parameter.

All _torchgeo_ and _microlifeclef_ examples have been updated as well as their config files.