### PR TITLE
GitHub pages doc: Updating worker for cartopy

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,7 +4,7 @@ on:
   push:
       branches:
         - main
-        - dev
+        - github-pages-doc
 jobs:
     test:
         name: Build doc & deploy

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Before proceeding, please make sure the following packages are installed on your
 - `pip`
 - `git`
 
+
 - **1. Clone the repository**
 
 Clone the Malpolon repository using `git` in the directory of your choice:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Before proceeding, please make sure the following packages are installed on your
 - `pip`
 - `git`
 
-
 - **1. Clone the repository**
 
 Clone the Malpolon repository using `git` in the directory of your choice:


### PR DESCRIPTION
# Reference Issues/PRs

# What does this implement/fix? Explain your changes.
This PR adds modifications to the github-pages documentation worker to correctly include the `cartopy` python package in the installation of the virtual environment.

Previously the build would fail when the package was listed in the `requirements.txt` because the virtual machine was lacking a system package.

Now the system package has been added through the worker file.

# Any other comments?
