### PR TITLE
Dependabot security updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ flake8==6.0.0
 geopandas==0.12.1
 hydra-core==1.2.0
 ipykernel==6.18.2
-ipython==8.7.0
+ipython==8.10.0
 jupyter==1.0.0
 jupyter-server==1.23.3
 jupyterlab==3.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ pytorch-lightning==1.7.7
 PyYAML==6.0
 rasterio==1.3.4
 scikit-learn==1.1.3
-scipy==1.9.3
+scipy==1.10.0
 shapely==2.0.0
 Sphinx==5.3.0
 stack-data==0.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ hydra-core==1.2.0
 ipykernel==6.18.2
 ipython==8.10.0
 jupyter==1.0.0
-jupyter-server==1.23.3
+jupyter-server==2.7.2
 jupyterlab==3.5.0
 lightning==1.9.5
 Markdown==3.4.1


### PR DESCRIPTION
# Reference Issues/PRs

# What does this implement/fix? Explain your changes.
## Major improvements
Security updates suggested by dependabot on secondary python packages. The version updates do not impair the unit tests and the training/inference loops.

The packages involved are:
- jupyter-server 1.23.3 -> 2.7.2
- ipython 8.7.0 -> 8.10.0
- scipy -> 1.9.3 -> 1.10.0

## Minor improvements

# Any other comments?
