### PR TITLE
Scenarios inference export

### DIFF
--- a/examples/ecologists/sentinel-2a/cnn_on_rgbnir_torchgeo.py
+++ b/examples/ecologists/sentinel-2a/cnn_on_rgbnir_torchgeo.py
@@ -328,7 +328,7 @@ def main(cfg: DictConfig) -> None:
                                                 ['model.', ''])
         preds, probas = datamodule.predict_logits_to_class(prediction)
         datamodule.export_predict_csv(preds, probas, single_point_query=query_point, out_name='prediction_point', return_csv=True)
-        print('Point prediction : ', prediction)
+        print('Point prediction : ', prediction.shape, prediction)
     else:
         trainer.fit(model, datamodule=datamodule, ckpt_path=cfg.run.checkpoint_path)
         trainer.validate(model, datamodule=datamodule)

--- a/examples/ecologists/sentinel-2a/cnn_on_rgbnir_torchgeo.py
+++ b/examples/ecologists/sentinel-2a/cnn_on_rgbnir_torchgeo.py
@@ -160,6 +160,7 @@ class Sentinel2TorchGeoDataModule(BaseDataModule):
             batch_size=self.inference_batch_size,
             num_workers=self.num_workers,
             pin_memory=self.pin_memory,
+            shuffle=False,
         )
         return dataloader
 
@@ -170,6 +171,7 @@ class Sentinel2TorchGeoDataModule(BaseDataModule):
             batch_size=self.inference_batch_size,
             num_workers=self.num_workers,
             pin_memory=self.pin_memory,
+            shuffle=False,
         )
         return dataloader
 
@@ -309,6 +311,8 @@ def main(cfg: DictConfig) -> None:
 
         # Option 1: Predict on the entire test dataset (Pytorch Lightning)
         predictions = model_loaded.predict(datamodule, trainer)
+        preds, probas = datamodule.predict_logits_to_class(predictions)
+        datamodule.export_predict_csv(preds, probas, out_name='predictions_test_dataset', return_csv=True)
         print('Test dataset prediction (extract) : ', predictions[:10])
 
         # Option 2: Predict 1 data point (Pytorch)
@@ -322,6 +326,8 @@ def main(cfg: DictConfig) -> None:
         prediction = model_loaded.predict_point(cfg.run.checkpoint_path,
                                                 test_data_point,
                                                 ['model.', ''])
+        preds, probas = datamodule.predict_logits_to_class(prediction)
+        datamodule.export_predict_csv(preds, probas, single_point_query=query_point, out_name='prediction_point', return_csv=True)
         print('Point prediction : ', prediction)
     else:
         trainer.fit(model, datamodule=datamodule, ckpt_path=cfg.run.checkpoint_path)

--- a/examples/ecologists/sentinel-2a/config/cnn_on_rgbnir_torchgeo_config.yaml
+++ b/examples/ecologists/sentinel-2a/config/cnn_on_rgbnir_torchgeo_config.yaml
@@ -12,7 +12,7 @@ trainer:
 
 run:
   predict: true
-  checkpoint_path: "../2023-11-24_18-26-47/checkpoint-epoch=00-step=3-val_multiclass_accuracy=0.0000.ckpt" # Relative to hydra.run.dir
+  checkpoint_path: ??? # Relative to hydra.run.dir
                                                                                                                                        
 model:
   provider_name: "timm"  # choose from ["timm", "torchvision"]

--- a/examples/ecologists/sentinel-2a/config/cnn_on_rgbnir_torchgeo_config.yaml
+++ b/examples/ecologists/sentinel-2a/config/cnn_on_rgbnir_torchgeo_config.yaml
@@ -12,7 +12,7 @@ trainer:
 
 run:
   predict: true
-  checkpoint_path: "../2023-11-08_17-54-29/checkpoint-epoch=00-step=3-val_multiclass_accuracy=0.0000.ckpt" # Relative to hydra.run.dir
+  checkpoint_path: "../2023-11-24_18-26-47/checkpoint-epoch=00-step=3-val_multiclass_accuracy=0.0000.ckpt" # Relative to hydra.run.dir
                                                                                                                                        
 model:
   provider_name: "timm"  # choose from ["timm", "torchvision"]

--- a/examples/ecologists/sentinel-2a/config/cnn_on_rgbnir_torchgeo_config.yaml
+++ b/examples/ecologists/sentinel-2a/config/cnn_on_rgbnir_torchgeo_config.yaml
@@ -12,7 +12,7 @@ trainer:
 
 run:
   predict: true
-  checkpoint_path: ??? # Relative to hydra.run.dir
+  checkpoint_path: ???  # Relative to hydra.run.dir
                                                                                                                                        
 model:
   provider_name: "timm"  # choose from ["timm", "torchvision"]

--- a/examples/ecologists/sentinel-2a/dataset/sentinel2_raster_torch_geo.csv
+++ b/examples/ecologists/sentinel-2a/dataset/sentinel2_raster_torch_geo.csv
@@ -2,6 +2,8 @@ observation_id,latitude,longitude,species_id,GBIF_species_id,GBIF_species_name,G
 1000,43.519427,3.796463,2,2927230,Stachys byzantina,Stachys,Lamiaceae,Plantae,p,10kmE373N287,test
 1001,43.520398,3.896501,0,2927190,Mentha suaveolens,Mentha,Lamiaceae,Plantae,8381,10kmE401N254,test
 1002,43.520398,3.896501,2,2927230,Stachys byzantina,Stachys,Lamiaceae,Plantae,p,10kmE373N287,test
+1012,43.520398,3.896501,4,2927230,Stachys byzantina,Stachys,Lamiaceae,Plantae,p,10kmE373N287,test
+1013,43.520398,3.896501,1,2927230,Stachys byzantina,Stachys,Lamiaceae,Plantae,p,10kmE373N287,test
 1003,43.526398,3.866501,0,2927190,Mentha suaveolens,Mentha,Lamiaceae,Plantae,8380,10kmE401N254,train
 1004,43.661663,3.788910,1,2792998,Ophrys apifera,Ophrys,Orchidaceae,Plantae,8166,10kmE369N234,train
 1005,43.6113,3.8707,2,2927230,Stachys byzantina,Stachys,Lamiaceae,Plantae,5142,10kmE369N234,train

--- a/examples/inference/sentinel-2a/cnn_on_rgbnir_torchgeo.py
+++ b/examples/inference/sentinel-2a/cnn_on_rgbnir_torchgeo.py
@@ -160,6 +160,7 @@ class Sentinel2TorchGeoDataModule(BaseDataModule):
             batch_size=self.inference_batch_size,
             num_workers=self.num_workers,
             pin_memory=self.pin_memory,
+            shuffle=False,
         )
         return dataloader
 
@@ -170,6 +171,7 @@ class Sentinel2TorchGeoDataModule(BaseDataModule):
             batch_size=self.inference_batch_size,
             num_workers=self.num_workers,
             pin_memory=self.pin_memory,
+            shuffle=False,
         )
         return dataloader
 
@@ -309,6 +311,8 @@ def main(cfg: DictConfig) -> None:
 
         # Option 1: Predict on the entire test dataset (Pytorch Lightning)
         predictions = model_loaded.predict(datamodule, trainer)
+        preds, probas = datamodule.predict_logits_to_class(predictions)
+        datamodule.export_predict_csv(preds, probas, out_name='predictions_test_dataset', return_csv=True)
         print('Test dataset prediction (extract) : ', predictions[:10])
 
         # Option 2: Predict 1 data point (Pytorch)
@@ -322,6 +326,8 @@ def main(cfg: DictConfig) -> None:
         prediction = model_loaded.predict_point(cfg.run.checkpoint_path,
                                                 test_data_point,
                                                 ['model.', ''])
+        preds, probas = datamodule.predict_logits_to_class(prediction)
+        datamodule.export_predict_csv(preds, probas, single_point_query=query_point, out_name='prediction_point', return_csv=True)
         print('Point prediction : ', prediction)
     else:
         trainer.fit(model, datamodule=datamodule, ckpt_path=cfg.run.checkpoint_path)

--- a/malpolon/data/data_module.py
+++ b/malpolon/data/data_module.py
@@ -253,8 +253,7 @@ class BaseDataModule(pl.LightningDataModule, ABC):
             _description_
         """
         device = torch.device("cpu")
-        activation = activation_fn()
-        probas = activation(predictions)
+        probas = activation_fn(predictions)
         probas, indices = torch.sort(probas, descending=True)
         probas, indices = probas.to(device), indices.to(device)
         predictions = self.get_test_dataset().unique_labels[indices]

--- a/malpolon/data/data_module.py
+++ b/malpolon/data/data_module.py
@@ -1,3 +1,10 @@
+"""This module provides a base class for data modules.
+
+Author: Theo Larcher <theo.larcher@inria.fr>
+        Titouan Lorieul <titouan.lorieul@inria.fr>
+
+"""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
@@ -18,6 +25,12 @@ if TYPE_CHECKING:
 
 
 class BaseDataModule(pl.LightningDataModule, ABC):
+    """Base class for data modules.
+
+    This class inherits pytorchlightining's LightningDataModule class
+    and provides a base class for data modules by re-defining steps
+    methods as well as adding new data manipulation methods.
+    """
     def __init__(
         self,
         train_batch_size: int = 32,
@@ -42,18 +55,51 @@ class BaseDataModule(pl.LightningDataModule, ABC):
     @property
     @abstractmethod
     def train_transform(self) -> Callable:
-        pass
+        """Return train data transforms.
+
+        Returns
+        -------
+        Callable
+            train data transforms
+        """
 
     @property
     @abstractmethod
     def test_transform(self) -> Callable:
-        pass
+        """Return test data transforms.
+
+        Returns
+        -------
+        Callable
+            test data transforms
+        """
 
     @abstractmethod
     def get_dataset(self, split: str, transform: Callable, **kwargs: Any) -> Dataset:
-        pass
+        """Return the dataset corresponding to the split.
+
+        Parameters
+        ----------
+        split : str
+            Type of dataset. Values must be on of ["train", "val",
+            "test"]
+        transform : Callable
+            data transforms to apply when loading the dataset
+
+        Returns
+        -------
+        Dataset
+            dataset corresponding to the split
+        """
 
     def get_train_dataset(self) -> Dataset:
+        """Call self.get_dataset to return the train dataset.
+
+        Returns
+        -------
+        Dataset
+            train dataset
+        """
         dataset = self.get_dataset(
             split="train",
             transform=self.train_transform,
@@ -61,6 +107,13 @@ class BaseDataModule(pl.LightningDataModule, ABC):
         return dataset
 
     def get_val_dataset(self) -> Dataset:
+        """Call self.get_dataset to return the validation dataset.
+
+        Returns
+        -------
+        Dataset
+            validation dataset
+        """
         dataset = self.get_dataset(
             split="val",
             transform=self.test_transform,
@@ -68,6 +121,13 @@ class BaseDataModule(pl.LightningDataModule, ABC):
         return dataset
 
     def get_test_dataset(self) -> Dataset:
+        """Call self.get_dataset to return the test dataset.
+
+        Returns
+        -------
+        Dataset
+            test dataset
+        """
         dataset = self.get_dataset(
             split="test",
             transform=self.test_transform,
@@ -76,6 +136,17 @@ class BaseDataModule(pl.LightningDataModule, ABC):
 
     # called for every GPU/machine
     def setup(self, stage: Optional[str] = None) -> None:
+        """Register the correct datasets to the class attributes.
+
+        Depending on the trainer's stage, this method will retrieve
+        the train, val or test dataset and register it as a class
+        attribute. The "predict" stage calls for the test dataset.
+
+        Parameters
+        ----------
+        stage : Optional[str], optional
+            trainer's stage, by default None (train)
+        """
         if stage in (None, "fit"):
             self.dataset_train = self.get_train_dataset()
             self.dataset_val = self.get_val_dataset()
@@ -87,11 +158,21 @@ class BaseDataModule(pl.LightningDataModule, ABC):
             self.dataset_predict = self.get_test_dataset()
 
     def prepare_data(self) -> None:
-        """Called once on CPU. Class states defined here are lost afterwards.
+        """Prepare data.
+
+        Called once on CPU. Class states defined here are lost afterwards.
         This method is intended for data downloading, tokenization,
-        permanent transformation..."""
+        permanent transformation...
+        """
 
     def train_dataloader(self) -> DataLoader:
+        """Return train dataloader instantiated with class attributes.
+
+        Returns
+        -------
+        DataLoader
+            train dataloader
+        """
         dataloader = DataLoader(
             self.dataset_train,
             sampler=self.sampler,
@@ -103,6 +184,13 @@ class BaseDataModule(pl.LightningDataModule, ABC):
         return dataloader
 
     def val_dataloader(self) -> DataLoader:
+        """Return validation dataloader instantiated with class attributes.
+
+        Returns
+        -------
+        DataLoader
+            Validation dataloader
+        """
         dataloader = DataLoader(
             self.dataset_val,
             sampler=self.sampler,
@@ -113,6 +201,13 @@ class BaseDataModule(pl.LightningDataModule, ABC):
         return dataloader
 
     def test_dataloader(self) -> DataLoader:
+        """Return test dataloader instantiated with class attributes.
+
+        Returns
+        -------
+        DataLoader
+            test dataloader
+        """
         dataloader = DataLoader(
             self.dataset_test,
             sampler=self.sampler,
@@ -123,6 +218,13 @@ class BaseDataModule(pl.LightningDataModule, ABC):
         return dataloader
 
     def predict_dataloader(self) -> DataLoader:
+        """Return predict dataloader instantiated with class attributes.
+
+        Returns
+        -------
+        DataLoader
+            predict dataloader
+        """
         dataloader = DataLoader(
             self.dataset_predict,
             sampler=self.sampler,
@@ -132,9 +234,26 @@ class BaseDataModule(pl.LightningDataModule, ABC):
         )
         return dataloader
 
-    def predict_logits_to_class(self, predictions: Union[np.ndarray, Tensor]) -> Tensor:
+    def predict_logits_to_class(self,
+                                predictions: Union[np.ndarray, Tensor],
+                                activation_fn: torch.nn.modules.activation = torch.nn.Softmax(dim=1)) -> Tensor:
+        """Convert the model's predictions to class labels.
+
+        This method applies an activation function to the model's
+        predictions and returns the corresponding class labels.
+
+        Parameters
+        ----------
+        predictions : Union[np.ndarray, Tensor]
+            model's predictions (raw logits), by default Softmax(dim=1)
+
+        Returns
+        -------
+        tuple[Union[np.ndarray, Tensor], Tensor]
+            _description_
+        """
         device = torch.device("cpu")
-        activation = torch.nn.Softmax(dim=1)
+        activation = activation_fn()
         probas = activation(predictions)
         probas, indices = torch.sort(probas, descending=True)
         probas, indices = probas.to(device), indices.to(device)
@@ -142,12 +261,45 @@ class BaseDataModule(pl.LightningDataModule, ABC):
         return predictions, probas
 
     def export_predict_csv(self,
-                           predictions,
-                           probas=None,
+                           predictions: np.ndarray,
+                           probas: Union[Tensor, np.ndarray] = None,
                            single_point_query: dict = None,
                            out_name: str = "predictions",
                            return_csv: bool = False,
                            **kwargs: Any) -> Any:
+        """Export predictions to csv file.
+
+        This method is used to export predictions to a csv file.
+        It can be used with a single point query or with the whole
+        test dataset.
+        This method is adapted for a classification task with an
+        observations file and multi-modal data.
+        Keys in the csv file match the ones used to inistantiate the
+        `RasterTorchGeoDataset` class, that is to say :
+        `observation_id`, `lon`, `lat`, `target_species_id`. The `crs`
+        key is also mandatory in the case of singl-point query.
+
+        Parameters
+        ----------
+        predictions : np.ndarray
+            model's predictions.
+        probas : Union[Tensor, np.ndarray], optional
+            predictions' raw logits or logits passed through an
+            activation function, by default None
+        single_point_query : dict, optional
+            query dictionnary of the single-point prediction, by default
+            None
+        out_name : str, optional
+            output CSV file name, by default "predictions"
+        return_csv : bool, optional
+            if true, the method returns the CSV as a pandas DataFrame,
+            by default False
+
+        Returns
+        -------
+        pandas.DataFrame
+            CSV content as a pandas DataFrame if `return_csv` is True
+        """
         out_name = out_name + ".csv" if not out_name.endswith(".csv") else out_name
         fp = Path('./') / Path(out_name)
         if single_point_query:
@@ -171,3 +323,4 @@ class BaseDataModule(pl.LightningDataModule, ABC):
         df.to_csv(fp, index=False, sep=',', **kwargs)
         if return_csv:
             return df
+        return None

--- a/malpolon/data/data_module.py
+++ b/malpolon/data/data_module.py
@@ -1,13 +1,19 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING
 
 from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import TYPE_CHECKING
 
+import numpy as np
+import pandas as pd
 import pytorch_lightning as pl
+import torch
+from torch import Tensor
 from torch.utils.data import DataLoader
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Optional
+    from typing import Any, Callable, Optional, Union
+
     from torch.utils.data import Dataset
 
 
@@ -125,3 +131,43 @@ class BaseDataModule(pl.LightningDataModule, ABC):
             pin_memory=self.pin_memory,
         )
         return dataloader
+
+    def predict_logits_to_class(self, predictions: Union[np.ndarray, Tensor]) -> Tensor:
+        device = torch.device("cpu")
+        activation = torch.nn.Softmax(dim=1)
+        probas = activation(predictions)
+        probas, indices = torch.sort(probas, descending=True)
+        probas, indices = probas.to(device), indices.to(device)
+        predictions = self.get_test_dataset().unique_labels[indices]
+        return predictions, probas
+
+    def export_predict_csv(self,
+                           predictions,
+                           probas=None,
+                           single_point_query: dict = None,
+                           out_name: str = "predictions",
+                           return_csv: bool = False,
+                           **kwargs: Any) -> Any:
+        out_name = out_name + ".csv" if not out_name.endswith(".csv") else out_name
+        fp = Path('./') / Path(out_name)
+        if single_point_query:
+            df = pd.DataFrame({'observation_id': [single_point_query['observation_id'] if 'observation_id' in single_point_query else None],
+                               'lon': [single_point_query['lon']],
+                               'lat': [single_point_query['lat']],
+                               'crs': [single_point_query['crs']],
+                               'target_species_id': [single_point_query['species_id'] if 'species_id' in single_point_query else None],
+                               'predictions': predictions[:, 0],
+                               'probas': probas[:, 0]})
+        else:
+            test_ds = self.get_test_dataset()
+            df = pd.DataFrame({'observation_id': test_ds.observation_ids,
+                               'lon': test_ds.coordinates[:, 0],
+                               'lat': test_ds.coordinates[:, 1],
+                               'target_species_id': test_ds.targets,
+                               'predictions': predictions[:, 0],
+                               'probas': [None] * len(predictions)})
+        if probas is not None:
+            df['probas'] = probas[:, 0]
+        df.to_csv(fp, index=False, sep=',', **kwargs)
+        if return_csv:
+            return df

--- a/malpolon/models/standard_prediction_systems.py
+++ b/malpolon/models/standard_prediction_systems.py
@@ -6,6 +6,7 @@ Author: Titouan Lorieul <titouan.lorieul@inria.fr>
 """
 
 from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import pytorch_lightning as pl
@@ -16,6 +17,7 @@ from .utils import check_loss, check_model, check_optimizer
 
 if TYPE_CHECKING:
     from typing import Any, Callable, Mapping, Optional, Union
+
     from torch import Tensor
 
 
@@ -158,8 +160,8 @@ class GenericPredictionSystem(pl.LightningModule):
         """
         replace[0] += '.' if not replace[0].endswith('.') else ''
         for key in list(state_dict):
-            print(key)
             state_dict[key.replace(replace[0], replace[1])] = state_dict.pop(key)
+        print(f'Inference state_dict: replaced {len(state_dict)} keys from "{replace[0]}" to "{replace[1]}"')
         return state_dict
 
     def predict(
@@ -221,6 +223,10 @@ class GenericPredictionSystem(pl.LightningModule):
         array
             Predicted tensor value.
         """
+        device = 'cuda' if torch.cuda.is_available() else 'cpu'
+        self.model.to(device)
+        data = data.to(device)
+
         ckpt = torch.load(checkpoint_path)
         if state_dict_replace_key:
             ckpt['state_dict'] = self.state_dict_replace_key(ckpt['state_dict'],


### PR DESCRIPTION
# Reference Issues/PRs

# What does this implement/fix? Explain your changes.

This PR offers new methods to export predictions to CSV files on your input CSV observation file or a single-point dictionary-like query.

This PR also brings a critical fix to how data labels are being queried in a torchgeo dataset by looking at the the field `observation_id` (previously took the label corresponding to the 1st element of a list of observations matching a coordinate).

## Major improvements

- `data_module`: Added methods `predict_logits_to_class(...)` and `export_predict_csv(...)`
- `torchgeo_dataset`: Added method `get_label(...)` under class `RasterTorchGeoDataset` to query data labels from their observation_id. Modified the class' `__getitem__()` accordingly.

## Minor improvements

- Added/Updated code documentation

# Any other comments?
