### PR TITLE
Get band mean and standard deviation for better normalization

### DIFF
--- a/malpolon/data/utils.py
+++ b/malpolon/data/utils.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import os
 import re
 from typing import Iterable, Union
+import warnings
 
 import numpy as np
 import rasterio
@@ -204,6 +205,8 @@ def get_mean_sd_by_band(path, compute_if_needed=False, ignore_zeros=True):
                     sd = np.std(arr)
                 means.append(float(mean))
                 sds.append(float(sd))
+            else : 
+                warnings.warn("Statistics metadata not found and computation not enabled.", UserWarning)
         except Exception as e:
             print(f"Error processing band {band}: {e}")
 


### PR DESCRIPTION
## :memo: Changelog

- [x] Add `get_mean_sd_by_band` function in `data/utils.py`
- [x] Add warning if tags are unavailable and computation does not take place

I believe it would be a good idea to check if this works properly within the `malpolon` environment. As mentioned IRL, I had trouble setting up an environment. In my poorly setup environment, rasterio's `src.tags(band_number)` returns an empty dict.
I've tested in other environments and this works properly, I never had such an issue before and do not find further hints about this bug for now. But if it works in a properly set environment, it works.

Just in case, I've added a warning in case the function does not return means and sds as its supposed to do.